### PR TITLE
Make compiletest_rs optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ either = { version = "1.1.0" }
 debugtrace = { version = "0.1.0" }
 tendril = { version = "0.4.3", optional = true }
 
-compiletest_rs = "0.7.1"
+compiletest_rs = { version = "0.7.1", optional = true }
 clippy = { version = ">0.0.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
On the upstream chomp crate, compiletest_rs is optional. If it is not, then this breaks functionality on the sgx platform.